### PR TITLE
Nokogiri syslib fix

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,7 +23,7 @@ case node['platform_family']
 when 'rhel', 'fedora', 'suse'
   default['xml']['packages'] = %w(libxml2-devel libxslt-devel)
 when 'ubuntu', 'debian'
-  default['xml']['packages'] = %w(libxml2-dev libxslt-dev)
+  default['xml']['packages'] = %w(libxml2-dev libxslt-dev zlib1g-dev)
 when 'freebsd', 'arch'
   default['xml']['packages'] = %w(libxml2 libxslt)
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -6,5 +6,6 @@ describe 'xml::default' do
   it 'installs the XML package' do
     expect(chef_run).to install_package('libxml2-dev')
     expect(chef_run).to install_package('libxslt-dev')
+    expect(chef_run).to install_package('zlib1g-dev')
   end
 end


### PR DESCRIPTION
This is a fix for the following issue: https://github.com/opscode-cookbooks/xml/issues/19
I have tested this on Ubuntu 12.04 and 14.04 in AWS EC2 using the Vanilla AMI for each. These images do not have zlib1g-dev installed on them which causes nokogiri to fail the build. 

Although the issue states that liblzma-dev was needed, I was able to build nokogiri without the lib being installed on either image.
