### PR TITLE
Move build essential compile time setting to attributes file

### DIFF
--- a/attributes/ruby.rb
+++ b/attributes/ruby.rb
@@ -1,0 +1,1 @@
+set['build-essential']['compile_time'] = true

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -26,7 +26,6 @@ execute 'apt-get update' do
   action :nothing
 end.run_action(:run) if 'debian' == node['platform_family']
 
-node.default['build-essential']['compile_time'] = true
 node.default['xml']['compiletime'] = true
 include_recipe 'build-essential::default'
 include_recipe 'xml::default'


### PR DESCRIPTION
With `node.default['build-essential']['compile_time']` in the recipe, the attribute is not set before `chef_gem` tries to install nokogiri, so the installation fails.

I have a suspicion (though I have not tested it) that this problem was introduced with Chef 12.1.