### PR TITLE
Uses apt recipe for update instead of shelling out for it manually

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -21,13 +21,14 @@
 
 include_recipe 'chef-sugar'
 
-execute 'apt-get update' do
-  ignore_failure true
-  action :nothing
-end.run_action(:run) if 'debian' == node['platform_family']
-
+node.default['apt']['compile_time_update'] = true
 node.default['build-essential']['compile_time'] = true
 node.default['xml']['compiletime'] = true
+
+if 'debian' == node['platform_family']
+  include_recipe 'apt'
+end
+
 include_recipe 'build-essential::default'
 include_recipe 'xml::default'
 


### PR DESCRIPTION
The presence of an `execute[apt-get update]` resource has the potential to conflict with other recipes which have a resource of an identical name - including the default apt recipe! By including the default apt recipe, we'll trigger an apt-get update in a reusable manner, and hopefully this method can also eliminate redundantly `apt-get update`ing multiple times in a single converge.