### PR TITLE
Use the right priority to set compile_time attribute

### DIFF
--- a/attributes/ruby.rb
+++ b/attributes/ruby.rb
@@ -1,1 +1,1 @@
-set['build-essential']['compile_time'] = true
+default['build-essential']['compile_time'] = true


### PR DESCRIPTION
Using node.set messes up with deployment tools and has no practical
advantage.
It is also deprecated in recent chef-client versions

Fix #35

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
